### PR TITLE
variaveis de ambiente

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
-spring.datasource.url=jdbc:mysql://containers-us-west-68.railway.app:7658/railway
-spring.datasource.username=root
-spring.datasource.password=cWK8xkMGHEVSigytRr2D
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-


### PR DESCRIPTION
As credenciais e conexão do banco devem estar em variáveis de ambiente por motivos de segurança.
